### PR TITLE
update GDAL install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: r
+language: bash
 sudo: true
 dist: xenial
 
-before_install:
-  - ./install-gis.sh
+script:
+  - bash install-gis.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # install-gis-ubuntu
 
-[![Build Status](https://travis-ci.org/Robinlovelace/install-gis-ubuntu.svg?branch=master)](htpps://travis-ci.org/Robinlovelace/install-gis-ubuntu)
+[![Build Status](https://travis-ci.org/Robinlovelace/install-gis-ubuntu.svg?branch=master)](https://travis-ci.org/Robinlovelace/install-gis-ubuntu)
 
 Inspired by a post on [installing commonly needed GIS software on Ubuntu](https://medium.com/@ramiroaznar/how-to-install-the-most-common-open-source-gis-applications-on-ubuntu-dbe9d612347b) and having recently got a new computer (well, a second hand [Lenovo laptop](http://www.ebay.co.uk/sch/PC-Laptops-Netbooks/177/i.html?_from=R40&_nkw=lenovo&_dcat=177&rt=nc&_mPrRngCbx=1&_udlo=0&_udhi=200)) with Ubuntu freshly installed, I decided to make the process of installing GIS software on it as reproducible as possible.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # install-gis-ubuntu
 
-![](https://travis-ci.org/Robinlovelace/install-gis-ubuntu.svg?branch=master)
+[![Build Status](https://travis-ci.org/Robinlovelace/install-gis-ubuntu.svg?branch=master)](htpps://travis-ci.org/Robinlovelace/install-gis-ubuntu)
 
 Inspired by a post on [installing commonly needed GIS software on Ubuntu](https://medium.com/@ramiroaznar/how-to-install-the-most-common-open-source-gis-applications-on-ubuntu-dbe9d612347b) and having recently got a new computer (well, a second hand [Lenovo laptop](http://www.ebay.co.uk/sch/PC-Laptops-Netbooks/177/i.html?_from=R40&_nkw=lenovo&_dcat=177&rt=nc&_mPrRngCbx=1&_udlo=0&_udhi=200)) with Ubuntu freshly installed, I decided to make the process of installing GIS software on it as reproducible as possible.
 

--- a/install-gis.sh
+++ b/install-gis.sh
@@ -15,7 +15,21 @@ echo deb https://josm.openstreetmap.de/apt alldist universe | sudo tee /etc/apt/
 wget -q https://josm.openstreetmap.de/josm-apt.key -O- | sudo apt-key add -
 sudo apt-get update
 sudo apt install josm
-sudo apt-get install -y gdal-bin libgdal-dev libgdal1-dev libproj-dev libgeos++-dev
+#sudo apt-get install -y gdal-bin libgdal-dev libgdal1-dev libproj-dev libgeos++-dev
+sudo apt-get install -y libproj-dev libgeos++-dev
+GDAL_URL="http://download.osgeo.org/gdal/CURRENT/"
+wget -O temp.html $GDAL_URL
+GDAL_VERSION=`cat temp.html | grep -o -P '(?<=gdal-).*(?=.tar.gz\")'`
+GDAL_FILE="gdal-"$GDAL_VERSION".tar.gz"
+rm temp.html
+wget $GDAL_URL$GDAL_FILE
+tar zxf $GDAL_FILE
+cd "gdal-"$GDAL_VERSION
+./configure
+make
+sudo make install
+cd ..
+rm -rf "gdal-"$GDAL_VERSION $GDAL_FILE
 
 # install R/RStudio - see
 # http://stackoverflow.com/questions/29667330


### PR DESCRIPTION
Versions of GDAL depend very much on versions of Ubuntu - for example compare [xenial](http://packages.ubuntu.com/xenial/gdal-bin) with [precise](http://packages.ubuntu.com/precise/gdal-bin). These lines ensure current GDAL regardless of platform.